### PR TITLE
Allow the package to build and run on FreeBSD

### DIFF
--- a/lib/tuntap_stubs.c
+++ b/lib/tuntap_stubs.c
@@ -27,6 +27,9 @@
 #include <net/if.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#ifdef __FreeBSD__
+#include <netinet/in.h>
+#endif /* __FreeBSD__ */
 #include <ifaddrs.h>
 #include <assert.h>
 
@@ -105,7 +108,7 @@ get_hwaddr(value devname) {
   CAMLreturn (hwaddr);
 }
 
-#elif defined(__APPLE__) && defined(__MACH__)
+#elif (defined(__APPLE__) && defined(__MACH__)) || defined(__FreeBSD__)
 #include <net/if_dl.h>
 #include <ifaddrs.h>
 
@@ -181,6 +184,7 @@ set_up_and_running(value dev)
 
   strncpy(ifr.ifr_name, String_val(dev), IFNAMSIZ);
   ifr.ifr_addr.sa_family = AF_INET;
+  ifr.ifr_addr.sa_len = IFNAMSIZ;
 
   if (ioctl(fd, SIOCGIFFLAGS, &ifr) == -1)
     {
@@ -215,6 +219,7 @@ set_ipv4(value dev, value ipv4, value netmask)
 
   strncpy(ifr.ifr_name, String_val(dev), IFNAMSIZ);
   ifr.ifr_addr.sa_family = AF_INET;
+  ifr.ifr_addr.sa_len = IFNAMSIZ;
 
   ret = inet_pton(AF_INET, String_val(ipv4), &(addr->sin_addr));
   if (ret == 0)


### PR DESCRIPTION
I have added some missing bits for the `tuntap` package to let it build and run on FreeBSD.  It mostly uses the Mac OS X code, except that I had to supplement the `ioctl()` request with some length information for working with IPv4 addresses -- otherwise `EINVAL` is returned.
