### PR TITLE
Work around OS X bug in getifaddrs concerning lo0@ipv6.

### DIFF
--- a/lib/tuntap_stubs.c
+++ b/lib/tuntap_stubs.c
@@ -396,7 +396,10 @@ iface_get(value ifap)
   struct sockaddr *broadaddr = c_ifap->ifa_dstaddr;
 #endif
 
-  if (broadaddr != NULL)
+  if (broadaddr != NULL &&
+      /* XXX Work around OS X bug.  */
+      (broadaddr->sa_family == AF_INET ||
+       broadaddr->sa_family == AF_INET6))
     {
       opt3 = caml_alloc(1, 0);
       Store_field(opt3, 0, caml_string_of_sa(broadaddr));

--- a/lib/tuntap_stubs.c
+++ b/lib/tuntap_stubs.c
@@ -397,7 +397,7 @@ iface_get(value ifap)
 #endif
 
   if (broadaddr != NULL &&
-      /* XXX Work around OS X bug.  */
+      /* XXX Work around *BSD bug. Github Pull Request #14 */
       (broadaddr->sa_family == AF_INET ||
        broadaddr->sa_family == AF_INET6))
     {


### PR DESCRIPTION
It seems OS X can return a dst_broadaddr that points to an invalid sockaddr,
both sa_family and sa_len are 0.

Without this change I'm unable to use getifaddrs from ocaml-tuntap since it
falls into the caml_string_of_sa call of broadaddr with an invalid sa_family,
which ends up raising:
  caml_invalid_argument("caml_string_of_sa: sa_family not supported");

This is the output of a simple getifaddrs call on my box:

interface lo0 flags = 0x8049
  ifa_addr family 18 len 20
interface lo0 flags = 0x8049
  ifa_addr family 30 len 28
  ifa_dstaddr family 30 len 28
interface lo0 flags = 0x8049
  ifa_addr family 2 len 16
  ifa_dstaddr family 2 len 16
interface lo0 flags = 0x8049
  ifa_addr family 30 len 28
  ifa_dstaddr family 0 len 0 <---- BUG

Here is the c program that prints the above:
int
main(void)
{
	struct ifaddrs *addrs, *ifa;
	struct sockaddr *sa;

	if (getifaddrs(&addrs) != 0)
		err(1, "getifaddrs");

	for (ifa = addrs; ifa != NULL; ifa = ifa->ifa_next) {
		printf("interface %s flags = 0x%x\n",
		    ifa->ifa_name, ifa->ifa_flags);
		sa = ifa->ifa_addr;
		printf("  ifa_addr family %d len %d\n",
		    sa->sa_family, sa->sa_len);
		sa = ifa->ifa_dstaddr;
		if (sa)
			printf("  ifa_dstaddr family %d len %d\n",
			    sa->sa_family, sa->sa_len);
	}
		
}
