### PR TITLE
Force a default of non-blocking for the Linux tuntap file descriptor.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,13 @@
-1.3.0 (05-Jun-2015):
+1.3.0 (07-Jun-2015):
 * Do not leak a file descriptor per tun interface (#12 via Justin Cormack)
 * Avoid the need for root access for persistent interfaces by not calling
   `SIOCSIFFLAGS` if not needed (#13 via Justin Cormack).
 * Use centralised Travis scripts.
 * Work around OS X bug in getifaddrs concerning lo0@ipv6 (#14)
+* Force a default of non-blocking for the Linux tuntap file descriptor.
+  This works around a kernel bug in 3.19+ that results in 0-byte reads
+  causing processes to spin (https://bugzilla.kernel.org/show_bug.cgi?id=96381).
+  Workaround is to open the device in nonblock mode, via Justin Cormack.
 
 1.2.0 (09-Jan-2015):
 * `set_ipaddr` renamed to `set_ipv4` since it can only set IPv4 addresses.

--- a/lib/tuntap_stubs.c
+++ b/lib/tuntap_stubs.c
@@ -58,7 +58,7 @@ tun_alloc(char *dev, int kind, int pi, int persist, int user, int group)
   struct ifreq ifr;
   int fd;
 
-  if ((fd = open("/dev/net/tun", O_RDWR)) == -1)
+  if ((fd = open("/dev/net/tun", O_RDWR | O_NONBLOCK)) == -1)
     tun_raise_error("open", -1);
 
   memset(&ifr, 0, sizeof(ifr));


### PR DESCRIPTION
This works around a kernel bug in 3.19+ that results in 0-byte reads
causing processes to spin (https://bugzilla.kernel.org/show_bug.cgi?id=96381).
Workaround is to open the device in nonblock mode, via Justin Cormack.