### PR TITLE
fix linking of binaries; remove build-test from opam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - PACKAGE="tuntap" OCAML_VERSION=4.02 TESTS=false
-  - PACKAGE="tuntap" OCAML_VERSION=4.03 TESTS=false
+  - PACKAGE="tuntap" OCAML_VERSION=4.02
+  - PACKAGE="tuntap" OCAML_VERSION=4.03

--- a/_tags
+++ b/_tags
@@ -4,5 +4,6 @@ true: package(ipaddr)
 <lib>: include
 
 <lib/tuntap.{cma,cmxa}>: use_tuntap
+<lib/tuntap.cmxs> : link_tuntap
 
 <test/**>: link_tuntap, package(oUnit lwt lwt.unix)

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -3,6 +3,10 @@ open Ocamlbuild_plugin
 let () =
   dispatch begin function
   | After_rules ->
+      flag ["link"; "library"; "ocaml"; "byte"; "use_tuntpo"]
+        (S ([A "-dllib"; A "-ltuntap_stubs"]));
+      flag ["link"; "library"; "ocaml"; "native"; "use_tuntap"]
+        (S ([A "-cclib"; A "-ltuntap_stubs"]));
       flag ["link"; "ocaml"; "link_tuntap"]
         (A "lib/libtuntap_stubs.a");
       dep ["link"; "ocaml"; "use_tuntap"]

--- a/opam
+++ b/opam
@@ -5,13 +5,11 @@ authors:      [ "Vincent Bernardoff <vb@luminar.eu.org>"
 license:      "ISC"
 homepage:     "https://github.com/mirage/ocaml-tuntap"
 dev-repo:     "https://github.com/mirage/ocaml-tuntap.git"
-bug-reports: "https://github.com/mirage/ocaml-tuntap/issues"
-tags:        [ "org:mirage" "org:xapi-project" ]
+bug-reports:  "https://github.com/mirage/ocaml-tuntap/issues"
+tags:         [ "org:mirage" "org:xapi-project" ]
 
-build:      [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
-build-test: [
-  [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true" ]
-  [ "ocaml" "pkg/pkg.ml" "test" ]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"
 ]
 
 depends: [

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -15,6 +15,7 @@ let () =
     Pkg.clib "lib/libtuntap_stubs.clib";
     Pkg.test "test/getifaddrs_test";
     Pkg.test "test/nonblock_read";
+    Pkg.test "test/nonblock_test";
     Pkg.test "test/open_close_test";
     Pkg.test "test/sendfd_test";
     Pkg.test "test/set_ipv4_test";


### PR DESCRIPTION
repositories where CI builds tests, and opam [version 1] builds and runs tests
of all dependencies

also fix linking of native and bytecode libraries: -ltuntap_stubs is required

//cc @yomimono this fixes the issue you described at https://github.com/mirage/ocaml-tuntap/pull/20#issuecomment-280823279 (I could reproduce it, and after applying this patch the undefined references are gone)