### PR TITLE
no need to specify v4:false, this is the default

### DIFF
--- a/test/getifaddrs_test.ml
+++ b/test/getifaddrs_test.ml
@@ -9,5 +9,5 @@ let () =
           n (V4.to_string a) (V4.Prefix.bits p)
       | n, `V6 (a, p) ->
         Printf.printf "%s -> %s/%d\n"
-          n (V6.to_string ~v4:false a) (V6.Prefix.bits p)
+          n (V6.to_string a) (V6.Prefix.bits p)
     ) addrs


### PR DESCRIPTION
and soon be gone...