### PR TITLE
Introduce get_mtu : string -> int, which uses SIOCGIFMTU to retrieve the MTU from the underlying interface

### DIFF
--- a/lib/tuntap.ml
+++ b/lib/tuntap.ml
@@ -20,6 +20,7 @@ type kind = Tap | Tun
 external opentun_stub : string -> kind -> bool -> int
   -> int -> int -> Unix.file_descr * string = "tun_opendev_byte" "tun_opendev"
 external get_macaddr : string -> string = "get_macaddr"
+external get_mtu : string -> int = "get_mtu"
 external set_ipv4 : string -> string -> string -> unit = "set_ipv4"
 external set_up_and_running : string -> unit = "set_up_and_running"
 

--- a/lib/tuntap.mli
+++ b/lib/tuntap.mli
@@ -51,6 +51,9 @@ val get_macaddr : string -> Macaddr.t
 (** [get_hwaddr devname] is the MAC address of interface
     [devname], as a raw string (not hexa). *)
 
+val get_mtu : string -> int
+(** [get_mtu devname] is the MTU of interface [devname]. *)
+
 val set_ipv4 : ?netmask:Ipaddr.V4.Prefix.t -> string -> Ipaddr.V4.t -> unit
 (** [set_ipv4 ~netmask dev ipaddr] assigns an [ipaddr] to interface
     [dev], with associated netmask [netmask] if specified. If

--- a/lib/tuntap_stubs.c
+++ b/lib/tuntap_stubs.c
@@ -91,29 +91,6 @@ tun_alloc(char *dev, int kind, int pi, int persist, int user, int group)
   return fd;
 }
 
-CAMLprim value
-get_macaddr(value devname) 
-{
-  CAMLparam1(devname);
-  CAMLlocal1(hwaddr);
-
-  int fd;
-  struct ifreq ifq;
-
-  fd = socket(PF_INET, SOCK_DGRAM, 0);
-  strcpy(ifq.ifr_name, String_val(devname));
-
-  if (ioctl(fd, SIOCGIFHWADDR, &ifq) == -1)
-    tun_raise_error("SIOCGIFHWADDR", fd);
-
-  close(fd);
-
-  hwaddr = caml_alloc_string(6);
-  memcpy(String_val(hwaddr), ifq.ifr_hwaddr.sa_data, 6);
-
-  CAMLreturn (hwaddr);
-}
-
 #elif (defined(__APPLE__) && defined(__MACH__)) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <net/if_dl.h>
 #include <ifaddrs.h>
@@ -133,9 +110,47 @@ tun_alloc(char *dev, int kind, int pi, int persist, int user, int group)
     tun_raise_error("open", -1);
   return fd;
 }
+#endif
+
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+CAMLprim value
+get_macaddr(value devname)
+{
+  CAMLparam1(devname);
+  CAMLlocal1(hwaddr);
+
+  int fd;
+  struct ifreq ifq;
+
+  fd = socket(AF_LOCAL, SOCK_DGRAM, 0);
+  strcpy(ifq.ifr_name, String_val(devname));
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+  ifq.ifr_addr.sa_len = 6;
+#endif /* __FreeBSD__ */
+
+#if defined(__linux__)
+  if (ioctl(fd, SIOCGIFHWADDR, &ifq) == -1)
+    tun_raise_error("SIOCGIFHWADDR", fd);
+#elif defined(__FreeBSD__)
+  if (ioctl(fd, SIOCGHWADDR, &ifq) == -1)
+    tun_raise_error("SIOCGHWADDR", fd);
+#else
+  if (ioctl(fd, SIOCGIFADDR, &ifq) == -1)
+    tun_raise_error("SIOCGIFADDR", fd);
+#endif
+
+  close(fd);
+
+  hwaddr = caml_alloc_string(6);
+  memcpy(String_val(hwaddr), ifq.ifr_addr.sa_data, 6);
+
+  CAMLreturn (hwaddr);
+}
+
+#elif (defined(__APPLE__) && defined(__MACH__))
 
 CAMLprim value
-get_macaddr(value devname) 
+get_macaddr(value devname)
 {
   CAMLparam1(devname);
   CAMLlocal1(v_mac);
@@ -171,6 +186,26 @@ get_macaddr(value devname)
 #endif
 
 // Code for all architectures
+
+CAMLprim value
+get_mtu(value devname)
+{
+  CAMLparam1(devname);
+  CAMLlocal1(mtu);
+
+  int fd;
+  struct ifreq ifq;
+
+  fd = socket(AF_INET, SOCK_DGRAM, 0);
+  strcpy(ifq.ifr_name, String_val(devname));
+
+  if (ioctl(fd, SIOCGIFMTU, &ifq) == -1)
+    tun_raise_error("SIOCGIFMTU", fd);
+
+  close(fd);
+
+  CAMLreturn (Val_int(ifq.ifr_mtu));
+}
 
 CAMLprim value
 set_up_and_running(value dev)


### PR DESCRIPTION
refactor ifdefs and get_macaddr on BSD systems

I tested these changes on FreeBSD and Linux. (anyone with access to MacOSX&OpenBSD, please test).