### PR TITLE
Add missing dependency on Unix

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,5 @@
 (library
  (name        tuntap)
  (public_name tuntap)
- (libraries   ipaddr macaddr)
+ (libraries   ipaddr macaddr unix)
  (c_names     tuntap_stubs))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.