### PR TITLE
Update cmdliner

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,3 @@
-;; The below is commented out because of CI issues. See #39
-;(executable
-; (name otunctl)
-; (libraries tuntap macaddr cmdliner))
+(executable
+ (name otunctl)
+ (libraries tuntap macaddr cmdliner))

--- a/bin/otunctl.ml
+++ b/bin/otunctl.ml
@@ -78,7 +78,8 @@ let tunctl optype devname mode user group pi =
 
 let cmd =
   let doc = "Create and destroy virtual interfaces." in
-  Term.(pure tunctl $ optype $ dev $ mode $ user $ group $ pi),
-  Term.info "otunctl" ~version:"1.0.0" ~doc
+  Cmd.v
+    (Cmd.info "otunctl" ~version:"1.0.0" ~doc)
+    Term.(const tunctl $ optype $ dev $ mode $ user $ group $ pi)
 
-let () = match Term.eval cmd with `Error _ -> exit 1 | _ -> exit 0
+let () = exit (Cmd.eval cmd)

--- a/tuntap.opam
+++ b/tuntap.opam
@@ -28,7 +28,7 @@ depends: [
   "macaddr" {>= "4.0.0"}
   "ounit" {with-test}
   "lwt" {with-test & >= "5.0.0"}
-  # "cmdliner" {with-dev-setup} # for bin/otunctl
+  "cmdliner" {with-test & >= "1.1.0"} # for bin/otunctl
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
This updates the example binary to cmdliner>=1.1.0 and adds back its dune file. Cmdliner is added as a test dependency even if it is not actually used for tests. This sets a lower bound on cmdliner which I think is more acceptable than an upper bound. And CI is happy! (I hope)

**Why was the dune file removed?** CI runs `dune build @install @check @runtest` which means it will check the example binary even if it's not to be installed nor is part of the tests. So cmdliner has to be a dependency, and the deprecation warnings from old cmdliner usage are fatal -- thus CI fails.

Maybe we can use `{with-dev-setup}` (since opam 2.2) eventually. I'm not sure what the exact semantics are of `with-dev-setup`.